### PR TITLE
Twitch API fix and performance increase when disabling subscriber emotes

### DIFF
--- a/src/main/java/net/blay09/mods/chattweaks/ChatTweaksConfig.java
+++ b/src/main/java/net/blay09/mods/chattweaks/ChatTweaksConfig.java
@@ -87,7 +87,9 @@ public class ChatTweaksConfig {
             EmoteRegistry.isLoading = true;
 
             try {
-                TwitchEmotesAPI.loadEmoteSets();
+                if (twitchSubscriberEmotes) {
+                    TwitchEmotesAPI.loadEmoteSets();
+                }
             } catch (Exception e) {
                 ChatTweaks.logger.error("Failed to load Twitch emote set mappings.");
             }

--- a/src/main/java/net/blay09/mods/chattweaks/chat/emotes/twitch/TwitchEmotesAPI.java
+++ b/src/main/java/net/blay09/mods/chattweaks/chat/emotes/twitch/TwitchEmotesAPI.java
@@ -42,7 +42,7 @@ public class TwitchEmotesAPI {
 			}
 			sb.append(emoteset);
 		}
-		String url = "https://api.twitch.tv/kraken/chat/emoticon_images?client_id=" + CLIENT_ID;
+		String url = "https://api.twitch.tv/kraken/chat/emoticon_images?api_version=5&client_id=" + CLIENT_ID;
 		if(emotesets.length > 0) {
 			url += "&emotesets=" + sb.toString();
 		}


### PR DESCRIPTION
Both TwitchEmotes sets and Twitch emotes jsons are ~250 MB combined and the sets json is still being loaded when subscriber emotes are disabled
![](https://user-images.githubusercontent.com/5104603/68399667-cffe8c80-0187-11ea-91ae-2396021e529d.png)

Adding a check for subscriber emotes config to sets loading dropped emotes loading time from ~2 minutes to 6 seconds.

Also an important thing: **please renew or change your Client ID** because it's not working right now (i've used a random ID for testing found in github)

and Kraken API was complaining about invalid version, adding `api_version=5` in the URL solved the issue