### PR TITLE
Remove check for "status" field in BTTV emotes json

### DIFF
--- a/src/main/java/net/blay09/mods/chattweaks/chat/emotes/bttv/BTTVChannelEmotes.java
+++ b/src/main/java/net/blay09/mods/chattweaks/chat/emotes/bttv/BTTVChannelEmotes.java
@@ -12,7 +12,7 @@ public class BTTVChannelEmotes {
     public BTTVChannelEmotes(String channelName) throws Exception {
         JsonObject root = CachedAPI.loadCachedAPI("https://api.betterttv.net/2/channels/" + channelName, "bttv_emotes_" + channelName + ".json", null);
         if (root != null) {
-            if (!root.has("status") && root.get("status").getAsInt() != 200) {
+            if (!root.has("urlTemplate") || !root.has("emotes")) {
                 throw new Exception("Failed to grab BTTV channel emotes.");
             }
             IEmoteGroup group = ChatTweaksAPI.registerEmoteGroup("BTTV-" + channelName);

--- a/src/main/java/net/blay09/mods/chattweaks/chat/emotes/bttv/BTTVEmotes.java
+++ b/src/main/java/net/blay09/mods/chattweaks/chat/emotes/bttv/BTTVEmotes.java
@@ -12,7 +12,7 @@ public class BTTVEmotes {
     public BTTVEmotes() throws Exception {
         JsonObject root = CachedAPI.loadCachedAPI("https://api.betterttv.net/2/emotes", "bttv_emotes.json", null);
         if (root != null) {
-            if (!root.has("status") && root.get("status").getAsInt() != 200) {
+            if (!root.has("urlTemplate") || !root.has("emotes")) {
                 throw new Exception("Failed to grab BTTV emotes.");
             }
             IEmoteGroup group = ChatTweaksAPI.registerEmoteGroup("BTTV");


### PR DESCRIPTION
For some reason they've introduced this breaking change without upping the API version number.
Now the code just checks for `urlTemplate` and `emotes` fields instead.

https://api.betterttv.net/2/emotes